### PR TITLE
Add class on plugin init

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -11,6 +11,9 @@ const init = function(player, options) {
     if (!AudioContext) {
       return;
     }
+
+    player.addClass('vjs-ssp');
+
     try {
       const tech = player.tech({ IWillNotUseThisInPlugins: true });
       const context = new AudioContext();


### PR DESCRIPTION
Get tests to pass by adding a plugin-specific class to the player on init.